### PR TITLE
Improve Error Handling

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -2,14 +2,22 @@ include_guard(GLOBAL)
 
 # Clones and checks out a Git repository from a remote location.
 #
+# If the `ERROR_VARIABLE` is specified, it will set the error message to that variable.
+# Otherwise, it will print the error message and halt the execution.
+#
 # Arguments:
 #   - URL: The URL of the remote Git repository.
 function(git_checkout URL)
+  cmake_parse_arguments(ARG "" "ERROR_VARIABLE" "" ${ARGN})
   execute_process(
     COMMAND git clone ${URL}
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to clone ${URL} (${RES})")
+    if(ARG_ERROR_VARIABLE)
+      set(${ARG_ERROR_VARIABLE} "Failed to clone ${URL} (${RES})" PARENT_SCOPE)
+    else()
+      message(FATAL_ERROR "Failed to clone ${URL} (${RES})")
+    endif()
   endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,4 +13,5 @@ endfunction()
 add_cmake_test(
   GitCheckoutTest.cmake
   "Check out a Git repository"
+  "Check out an invalid Git repository"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,5 @@ add_cmake_test(
   GitCheckoutTest.cmake
   "Check out a Git repository"
   "Check out an invalid Git repository"
+  "Check out an invalid Git repository with error variable specified"
 )

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -45,6 +45,21 @@ if("Check out an invalid Git repository" MATCHES ${TEST_MATCHES})
   endif()
 endif()
 
+if("Check out an invalid Git repository with error variable specified" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  include(GitCheckout)
+  git_checkout(
+    https://github.com/threeal/invalid-project
+    ERROR_VARIABLE ERR
+  )
+
+  set(EXPECTED_FATAL_ERROR_MESSAGE "Failed to clone https://github.com/threeal/invalid-project (128)")
+  if(NOT ${ERR} STREQUAL EXPECTED_FATAL_ERROR_MESSAGE)
+    message(FATAL_ERROR "It should fail to check out because of `${EXPECTED_FATAL_ERROR_MESSAGE}`, but got `${ERR}` instead")
+  endif()
+endif()
+
 if(TEST_COUNT LESS_EQUAL 0)
   message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
 endif()

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -5,7 +5,6 @@ endif()
 
 set(TEST_COUNT 0)
 
-# Add more test cases here.
 if("Check out a Git repository" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 
@@ -18,6 +17,31 @@ if("Check out a Git repository" MATCHES ${TEST_MATCHES})
 
   if(NOT EXISTS project-starter)
     message(FATAL_ERROR "project-starter should exist")
+  endif()
+endif()
+
+if("Check out an invalid Git repository" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  set(MOCK_MESSAGE on)
+  macro(message MODE MESSAGE)
+    if(MOCK_MESSAGE)
+      if(${MODE} STREQUAL FATAL_ERROR)
+        set(FATAL_ERROR_MESSAGE "${MESSAGE}" PARENT_SCOPE)
+      endif()
+    else()
+      _message(${MODE} ${MESSAGE})
+    endif()
+  endmacro()
+
+  include(GitCheckout)
+  git_checkout(https://github.com/threeal/invalid-project)
+
+  set(MOCK_MESSAGE off)
+
+  set(EXPECTED_FATAL_ERROR_MESSAGE "Failed to clone https://github.com/threeal/invalid-project (128)")
+  if(NOT FATAL_ERROR_MESSAGE STREQUAL EXPECTED_FATAL_ERROR_MESSAGE)
+    message(FATAL_ERROR "It should fail to check out because of `${EXPECTED_FATAL_ERROR_MESSAGE}`, but got `${FATAL_ERROR_MESSAGE}` instead")
   endif()
 endif()
 


### PR DESCRIPTION
This pull request resolves #5 by introducing the following changes:
- Adds support to pass an error variable to the `git_checkout` function by specifying the `ERROR_VARIABLE` argument. If the variable is provided, it will set an error message to that variable on failure; otherwise, it will print the error message and halt the execution.
- Adds testing to test checking out an invalid Git repository and checks if the error message matches the expected error message.