### PR TITLE
Add Error Handling Function

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -1,5 +1,22 @@
 include_guard(GLOBAL)
 
+# Set error with a specified message.
+#
+# If the `ERROR_VARIABLE` is specified, it will set the error message to that variable.
+# Otherwise, it will print the error message and halt the execution.
+#
+# Arguments:
+#   - MESSAGE: The error message.
+macro(_set_error MESSAGE)
+  cmake_parse_arguments(ARG "" "ERROR_VARIABLE" "" ${ARGN})
+  if(ARG_ERROR_VARIABLE)
+    set(${ARG_ERROR_VARIABLE} "${MESSAGE}" PARENT_SCOPE)
+    return()
+  else()
+    message(FATAL_ERROR "${MESSAGE}")
+  endif()
+endmacro()
+
 # Clones and checks out a Git repository from a remote location.
 #
 # If the `ERROR_VARIABLE` is specified, it will set the error message to that variable.
@@ -14,10 +31,9 @@ function(git_checkout URL)
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)
-    if(ARG_ERROR_VARIABLE)
-      set(${ARG_ERROR_VARIABLE} "Failed to clone ${URL} (${RES})" PARENT_SCOPE)
-    else()
-      message(FATAL_ERROR "Failed to clone ${URL} (${RES})")
-    endif()
+    _set_error(
+      "Failed to clone ${URL} (${RES})"
+      ERROR_VARIABLE ${ARG_ERROR_VARIABLE}
+    )
   endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,5 +16,4 @@ add_cmake_test(
   "Set error with variable specified"
   "Check out a Git repository"
   "Check out an invalid Git repository"
-  "Check out an invalid Git repository with error variable specified"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,8 @@ endfunction()
 
 add_cmake_test(
   GitCheckoutTest.cmake
+  "Set error"
+  "Set error with variable specified"
   "Check out a Git repository"
   "Check out an invalid Git repository"
   "Check out an invalid Git repository with error variable specified"

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -5,6 +5,48 @@ endif()
 
 set(TEST_COUNT 0)
 
+if("Set error" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  set(MOCK_MESSAGE on)
+  macro(message MODE MESSAGE)
+    if(MOCK_MESSAGE)
+      set(${MODE}_MESSAGE "${MESSAGE}" PARENT_SCOPE)
+    else()
+      _message(${MODE} ${MESSAGE})
+    endif()
+  endmacro()
+
+  include(GitCheckout)
+
+  function(foo)
+    _set_error("Unknown error")
+  endfunction()
+
+  foo()
+
+  set(MOCK_MESSAGE off)
+  if(NOT FATAL_ERROR_MESSAGE STREQUAL "Unknown error")
+    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${FATAL_ERROR_MESSAGE}'")
+  endif()
+endif()
+
+if("Set error with variable specified" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  include(GitCheckout)
+
+  function(foo)
+    _set_error("Unknown error" ERROR_VARIABLE ERR)
+  endfunction()
+
+  foo()
+
+  if(NOT ERR STREQUAL "Unknown error")
+    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${ERR}'")
+  endif()
+endif()
+
 if("Check out a Git repository" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -58,36 +58,11 @@ if("Check out a Git repository" MATCHES ${TEST_MATCHES})
   git_checkout(https://github.com/threeal/project-starter)
 
   if(NOT EXISTS project-starter)
-    message(FATAL_ERROR "project-starter should exist")
+    message(FATAL_ERROR "The 'project-starter' directory should exist")
   endif()
 endif()
 
 if("Check out an invalid Git repository" MATCHES ${TEST_MATCHES})
-  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
-
-  set(MOCK_MESSAGE on)
-  macro(message MODE MESSAGE)
-    if(MOCK_MESSAGE)
-      if(${MODE} STREQUAL FATAL_ERROR)
-        set(FATAL_ERROR_MESSAGE "${MESSAGE}" PARENT_SCOPE)
-      endif()
-    else()
-      _message(${MODE} ${MESSAGE})
-    endif()
-  endmacro()
-
-  include(GitCheckout)
-  git_checkout(https://github.com/threeal/invalid-project)
-
-  set(MOCK_MESSAGE off)
-
-  set(EXPECTED_FATAL_ERROR_MESSAGE "Failed to clone https://github.com/threeal/invalid-project (128)")
-  if(NOT FATAL_ERROR_MESSAGE STREQUAL EXPECTED_FATAL_ERROR_MESSAGE)
-    message(FATAL_ERROR "It should fail to check out because of `${EXPECTED_FATAL_ERROR_MESSAGE}`, but got `${FATAL_ERROR_MESSAGE}` instead")
-  endif()
-endif()
-
-if("Check out an invalid Git repository with error variable specified" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 
   include(GitCheckout)
@@ -96,9 +71,9 @@ if("Check out an invalid Git repository with error variable specified" MATCHES $
     ERROR_VARIABLE ERR
   )
 
-  set(EXPECTED_FATAL_ERROR_MESSAGE "Failed to clone https://github.com/threeal/invalid-project (128)")
-  if(NOT ${ERR} STREQUAL EXPECTED_FATAL_ERROR_MESSAGE)
-    message(FATAL_ERROR "It should fail to check out because of `${EXPECTED_FATAL_ERROR_MESSAGE}`, but got `${ERR}` instead")
+  set(EXPECTED_ERR "Failed to clone https://github.com/threeal/invalid-project (128)")
+  if(NOT ${ERR} STREQUAL EXPECTED_ERR)
+    message(FATAL_ERROR "It should fail to check out because of '${EXPECTED_ERR}' but instead got '${ERR}'")
   endif()
 endif()
 


### PR DESCRIPTION
This pull request resolves #7 by introducing the following changes:
- Adds a `_set_error` function alongside its testing for setting an error message to a given variable or printing the error message and halting the execution.
- Merges tests for checking out an invalid Git repository into one test.