### PR TITLE
Separate Tests for Each Function

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,8 +12,12 @@ endfunction()
 
 add_cmake_test(
   GitCheckoutTest.cmake
-  "Set error"
-  "Set error with variable specified"
   "Check out a Git repository"
   "Check out an invalid Git repository"
+)
+
+add_cmake_test(
+  SetErrorTest.cmake
+  "Set error"
+  "Set error with variable specified"
 )

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -5,48 +5,6 @@ endif()
 
 set(TEST_COUNT 0)
 
-if("Set error" MATCHES ${TEST_MATCHES})
-  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
-
-  set(MOCK_MESSAGE on)
-  macro(message MODE MESSAGE)
-    if(MOCK_MESSAGE)
-      set(${MODE}_MESSAGE "${MESSAGE}" PARENT_SCOPE)
-    else()
-      _message(${MODE} ${MESSAGE})
-    endif()
-  endmacro()
-
-  include(GitCheckout)
-
-  function(foo)
-    _set_error("Unknown error")
-  endfunction()
-
-  foo()
-
-  set(MOCK_MESSAGE off)
-  if(NOT FATAL_ERROR_MESSAGE STREQUAL "Unknown error")
-    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${FATAL_ERROR_MESSAGE}'")
-  endif()
-endif()
-
-if("Set error with variable specified" MATCHES ${TEST_MATCHES})
-  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
-
-  include(GitCheckout)
-
-  function(foo)
-    _set_error("Unknown error" ERROR_VARIABLE ERR)
-  endfunction()
-
-  foo()
-
-  if(NOT ERR STREQUAL "Unknown error")
-    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${ERR}'")
-  endif()
-endif()
-
 if("Check out a Git repository" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 

--- a/test/SetErrorTest.cmake
+++ b/test/SetErrorTest.cmake
@@ -1,0 +1,52 @@
+# Matches everything if not defined
+if(NOT TEST_MATCHES)
+  set(TEST_MATCHES ".*")
+endif()
+
+set(TEST_COUNT 0)
+
+if("Set error" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  set(MOCK_MESSAGE on)
+  macro(message MODE MESSAGE)
+    if(MOCK_MESSAGE)
+      set(${MODE}_MESSAGE "${MESSAGE}" PARENT_SCOPE)
+    else()
+      _message(${MODE} ${MESSAGE})
+    endif()
+  endmacro()
+
+  include(GitCheckout)
+
+  function(foo)
+    _set_error("Unknown error")
+  endfunction()
+
+  foo()
+
+  set(MOCK_MESSAGE off)
+  if(NOT FATAL_ERROR_MESSAGE STREQUAL "Unknown error")
+    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${FATAL_ERROR_MESSAGE}'")
+  endif()
+endif()
+
+if("Set error with variable specified" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  include(GitCheckout)
+
+  function(foo)
+    _set_error("Unknown error" ERROR_VARIABLE ERR)
+  endfunction()
+
+  foo()
+
+  if(NOT ERR STREQUAL "Unknown error")
+    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${ERR}'")
+  endif()
+endif()
+
+if(TEST_COUNT LESS_EQUAL 0)
+  message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
+endif()


### PR DESCRIPTION
This pull request resolves #9 by separating tests for the `_set_error` function into a `SetErrorTest.cmake` file, effectively separating tests for each function.