### PR TITLE
Add License Notice to Exported Files

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -1,3 +1,6 @@
+# This code is licensed under the terms of the MIT License.
+# Copyright (c) 2024 Alfi Maulana
+
 include_guard(GLOBAL)
 
 # Set error with a specified message.


### PR DESCRIPTION
This pull request resolves #13 by adding a license notice on top of the `cmake/GitCheckout.cmake` file.