### PR TITLE
Add Support to Check Out on a Specific Directory

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -29,13 +29,14 @@ endmacro()
 #   - URL: The URL of the remote Git repository.
 #
 # Optional arguments:
+#   - DIRECTORY: The path of the directory to check out the Git repository.
 #   - REF: The reference (branch, tag, or commit) to check out the Git repository.
 function(git_checkout URL)
-  cmake_parse_arguments(ARG "" "REF;ERROR_VARIABLE" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "DIRECTORY;REF;ERROR_VARIABLE" "" ${ARGN})
 
   # Clones the Git repository.
   execute_process(
-    COMMAND git clone ${URL}
+    COMMAND git clone ${URL} ${ARG_DIRECTORY}
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)
@@ -45,18 +46,20 @@ function(git_checkout URL)
     )
   endif()
 
-  # Determines the directory of the cloned Git repository.
-  string(REGEX REPLACE ".*/" "" GIT_DIR ${URL})
+  if(NOT DEFINED ARG_DIRECTORY)
+    # Determines the directory of the cloned Git repository if it is not specified.
+    string(REGEX REPLACE ".*/" "" ARG_DIRECTORY ${URL})
+  endif()
 
   if(ARG_REF)
     # Checks out the Git repository to a specific reference.
     execute_process(
-      COMMAND git -C ${GIT_DIR} checkout ${ARG_REF}
+      COMMAND git -C ${ARG_DIRECTORY} checkout ${ARG_REF}
       RESULT_VARIABLE RES
     )
     if(NOT RES EQUAL 0)
       _set_error(
-        "Failed to check out '${GIT_DIR}' to '${ARG_REF}' (${RES})"
+        "Failed to check out '${ARG_DIRECTORY}' to '${ARG_REF}' (${RES})"
         ERROR_VARIABLE ${ARG_ERROR_VARIABLE}
       )
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_cmake_test(
   GitCheckoutTest.cmake
   "Check out a Git repository"
   "Check out an invalid Git repository"
+  "Check out a Git repository to a specific directory"
   "Check out a Git repository on a specific ref"
   "Check out a Git repository on a specific invalid ref"
 )

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -35,6 +35,21 @@ if("Check out an invalid Git repository" MATCHES ${TEST_MATCHES})
   endif()
 endif()
 
+if("Check out a Git repository to a specific directory" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  if(EXISTS some-directory)
+    file(REMOVE_RECURSE some-directory)
+  endif()
+
+  include(GitCheckout)
+  git_checkout(https://github.com/threeal/project-starter DIRECTORY some-directory)
+
+  if(NOT EXISTS some-directory)
+    message(FATAL_ERROR "The 'some-directory' directory should exist")
+  endif()
+endif()
+
 if("Check out a Git repository on a specific ref" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 


### PR DESCRIPTION
This pull request resolves #15 by adding a `DIRECTORY` argument in the `git_checkout` function for specifying the output directory of the cloned Git repository. It also adds testing to test checking out a Git repository to a specific directory.