### PR TITLE
Fix Git Complete Check Out Assertion

### DIFF
--- a/test/GitAssert.cmake
+++ b/test/GitAssert.cmake
@@ -8,7 +8,7 @@ function(assert_git_complete_checkout DIRECTORY)
   endif()
 
   execute_process(
-    COMMAND git -C ${DIRECTORY} diff --no-patch --exit-code
+    COMMAND git -C ${DIRECTORY} diff --no-patch --exit-code HEAD
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)


### PR DESCRIPTION
This pull request fixes an issue in the `assert_git_complete_checkout` function that has a missing `HEAD` argument when checking for Git diff. This issue causes the function to not be able to correctly assert if there's a file missing during checkout. This change should be part of #19.