### PR TITLE
Add Support to Do Sparse Check Out

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -31,8 +31,9 @@ endmacro()
 # Optional arguments:
 #   - DIRECTORY: The path of the directory to check out the Git repository.
 #   - REF: The reference (branch, tag, or commit) to check out the Git repository.
+#   - SPARSE_CHECKOUT: A list of files to check out sparsely.
 function(git_checkout URL)
-  cmake_parse_arguments(ARG "" "DIRECTORY;REF;ERROR_VARIABLE" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "DIRECTORY;REF;ERROR_VARIABLE" "SPARSE_CHECKOUT" ${ARGN})
 
   # Clones the Git repository.
   execute_process(
@@ -49,6 +50,19 @@ function(git_checkout URL)
   if(NOT DEFINED ARG_DIRECTORY)
     # Determines the directory of the cloned Git repository if it is not specified.
     string(REGEX REPLACE ".*/" "" ARG_DIRECTORY ${URL})
+  endif()
+
+  if(ARG_SPARSE_CHECKOUT)
+    execute_process(
+      COMMAND git -C ${ARG_DIRECTORY} sparse-checkout set ${ARG_SPARSE_CHECKOUT}
+      RESULT_VARIABLE RES
+    )
+    if(NOT RES EQUAL 0)
+      _set_error(
+        "Failed to sparse checkout '${ARG_DIRECTORY}' (${RES})"
+        ERROR_VARIABLE ${ARG_ERROR_VARIABLE}
+      )
+    endif()
   endif()
 
   # Checks out the Git repository.

--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -36,7 +36,7 @@ function(git_checkout URL)
 
   # Clones the Git repository.
   execute_process(
-    COMMAND git clone --no-checkout ${URL} ${ARG_DIRECTORY}
+    COMMAND git clone --filter=blob:none --no-checkout ${URL} ${ARG_DIRECTORY}
     RESULT_VARIABLE RES
   )
   if(NOT RES EQUAL 0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_cmake_test(
   "Check out a Git repository to a specific directory"
   "Check out a Git repository on a specific ref"
   "Check out a Git repository on a specific invalid ref"
+  "Check out a Git repository sparsely"
 )
 
 add_cmake_test(

--- a/test/GitAssert.cmake
+++ b/test/GitAssert.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.3)
+
 # Asserts whether a Git repository is checked out completely.
 #
 # Arguments:
@@ -14,4 +16,25 @@ function(assert_git_complete_checkout DIRECTORY)
   if(NOT RES EQUAL 0)
     message(FATAL_ERROR "the repository should be checked out completely (${RES})")
   endif()
+endfunction()
+
+# Asserts whether a Git repository is checked out sparsely.
+#
+# Arguments:
+#   - DIRECTORY: The path of the directory to check out the Git repository.
+#
+# Optional arguments:
+#   - FILES: A list of files that should be checked out sparsely.
+function(assert_git_sparse_checkout DIRECTORY)
+  cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+
+  assert_git_complete_checkout(${DIRECTORY})
+
+  file(GLOB FILES RELATIVE ${DIRECTORY} "${DIRECTORY}/**/*")
+  list(FILTER FILES EXCLUDE REGEX ${DIRECTORY}/.git)
+  foreach(FILE ${FILES})
+    if(NOT FILE IN_LIST ARG_FILES)
+      message(FATAL_ERROR "the '${FILE}' should not exist")
+    endif()
+  endforeach()
 endfunction()

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -88,6 +88,24 @@ if("Check out a Git repository on a specific invalid ref" MATCHES ${TEST_MATCHES
   endif()
 endif()
 
+if("Check out a Git repository sparsely" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  if(EXISTS opencv)
+    file(REMOVE_RECURSE opencv)
+  endif()
+
+  git_checkout(
+    https://github.com/opencv/opencv
+    SPARSE_CHECKOUT modules/core samples/gpu
+  )
+
+  assert_git_sparse_checkout(
+    opencv
+    FILES modules/core samples/gpu
+  )
+endif()
+
 if(TEST_COUNT LESS_EQUAL 0)
   message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
 endif()


### PR DESCRIPTION
This pull request resolves #17 by introducing the following changes:
- Filters blobs when cloning a Git repository in the `git_checkout` function to prevent downloading blobs during clone.
- Adds a `SPARSE_CHECKOUT` argument in the `git_checkout` function for specifying a list of files to be checked out sparsely.
- Adds testing for checking out a Git repository sparsely.