### PR TITLE
Add Git Directory Assertion For Testing

### DIFF
--- a/test/GitAssert.cmake
+++ b/test/GitAssert.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 
 # Asserts whether the given path is a Git directory.
 #
-# It asserts whether the given path exists and is a directory.
+# It asserts whether the given path exists, is a directory, and contains a Git repository.
 #
 # Arguments:
 #   - PATH: The path to check.
@@ -13,6 +13,16 @@ function(_assert_git_directory PATH)
 
   if(NOT IS_DIRECTORY ${PATH})
     message(FATAL_ERROR "the '${PATH}' path should be a directory")
+  endif()
+
+  execute_process(
+    COMMAND git -C ${PATH} status
+    RESULT_VARIABLE RES
+  )
+  if(RES EQUAL 128)
+    message(FATAL_ERROR "the '${PATH}' directory should contains a Git repository")
+  elseif(NOT RES EQUAL 0)
+    message(FATAL_ERROR "failed to get the Git status of the '${PATH}' directory (${RES})")
   endif()
 endfunction()
 


### PR DESCRIPTION
This pull request resolves #27 by adding a private `_assert_git_directory` function to assert whether a given path exists, is a directory, and contains a Git repository.