### PR TITLE
Reorder Tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,12 +11,9 @@ function(add_cmake_test FILE)
 endfunction()
 
 add_cmake_test(
-  GitCheckoutTest.cmake
-  "Check out a Git repository"
-  "Check out a Git repository to a specific directory"
-  "Check out a Git repository on a specific ref"
-  "Check out a Git repository on a specific invalid ref"
-  "Check out a Git repository sparsely"
+  SetErrorTest.cmake
+  "Set error"
+  "Set error with variable specified"
 )
 
 add_cmake_test(
@@ -27,7 +24,10 @@ add_cmake_test(
 )
 
 add_cmake_test(
-  SetErrorTest.cmake
-  "Set error"
-  "Set error with variable specified"
+  GitCheckoutTest.cmake
+  "Check out a Git repository"
+  "Check out a Git repository to a specific directory"
+  "Check out a Git repository on a specific ref"
+  "Check out a Git repository on a specific invalid ref"
+  "Check out a Git repository sparsely"
 )


### PR DESCRIPTION
This pull request resolves #29 by reordering tests based on function dependencies so that tests are run in the following order:
- Tests in the `SetErrorTest.cmake` module.
- Tests in the `GitCloneTest.cmake` module.
- Tests in the `GitCheckoutTest.cmake` module.