### PR TITLE
Add Function for Asserting Message

### DIFF
--- a/test/Assertion.cmake
+++ b/test/Assertion.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 cmake_minimum_required(VERSION 3.3)
 
 # Asserts whether the given path is a Git directory.

--- a/test/Assertion.cmake
+++ b/test/Assertion.cmake
@@ -14,6 +14,21 @@ macro(message MODE MESSAGE)
   endif()
 endmacro()
 
+# Asserts whether the latest message is equal to the expected message.
+#
+# It asserts whether the `${MODE}_MESSAGE` variable set by the `message` function mock
+# is equal to the given expected message.
+#
+# Arguments:
+#   - MODE: The message mode.
+#   - EXPECTED_MESSAGE: The expected message.
+function(assert_message MODE EXPECTED_MESSAGE)
+  if(NOT "${${MODE}_MESSAGE}" STREQUAL "${EXPECTED_MESSAGE}")
+    set(MOCK_MESSAGE OFF)
+    message(FATAL_ERROR "it should receive a ${MODE} message containing '${EXPECTED_MESSAGE}' but instead got '${${MODE}_MESSAGE}'")
+  endif()
+endfunction()
+
 # Asserts whether the given path is a Git directory.
 #
 # It asserts whether the given path exists, is a directory, and contains a Git repository.

--- a/test/Assertion.cmake
+++ b/test/Assertion.cmake
@@ -2,6 +2,18 @@ include_guard(GLOBAL)
 
 cmake_minimum_required(VERSION 3.3)
 
+# Mocks the implementation of the `message` function.
+#
+# If `MOCK_MESSAGE` is enabled, it will set `${MODE}_MESSAGE` to the given message instead of
+# displaying the message in the log.
+macro(message MODE MESSAGE)
+  if(MOCK_MESSAGE)
+    set(${MODE}_MESSAGE "${MESSAGE}" PARENT_SCOPE)
+  else()
+    _message(${MODE} ${MESSAGE})
+  endif()
+endmacro()
+
 # Asserts whether the given path is a Git directory.
 #
 # It asserts whether the given path exists, is a directory, and contains a Git repository.

--- a/test/GitCheckoutTest.cmake
+++ b/test/GitCheckoutTest.cmake
@@ -7,7 +7,7 @@ set(TEST_COUNT 0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-include(GitAssert)
+include(Assertion)
 include(GitCheckout)
 
 if("Check out a Git repository" MATCHES ${TEST_MATCHES})

--- a/test/GitCloneTest.cmake
+++ b/test/GitCloneTest.cmake
@@ -7,7 +7,7 @@ set(TEST_COUNT 0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-include(GitAssert)
+include(Assertion)
 include(GitCheckout)
 
 if("Incompletely clone a Git repository" MATCHES ${TEST_MATCHES})

--- a/test/SetErrorTest.cmake
+++ b/test/SetErrorTest.cmake
@@ -21,10 +21,7 @@ if("Set error" MATCHES ${TEST_MATCHES})
 
   foo()
 
-  if(NOT FATAL_ERROR_MESSAGE STREQUAL "Unknown error")
-    set(MOCK_MESSAGE OFF)
-    message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${FATAL_ERROR_MESSAGE}'")
-  endif()
+  assert_message(FATAL_ERROR "Unknown error")
 endif()
 
 if("Set error with variable specified" MATCHES ${TEST_MATCHES})

--- a/test/SetErrorTest.cmake
+++ b/test/SetErrorTest.cmake
@@ -5,19 +5,15 @@ endif()
 
 set(TEST_COUNT 0)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+include(Assertion)
+include(GitCheckout)
+
 if("Set error" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
 
-  set(MOCK_MESSAGE on)
-  macro(message MODE MESSAGE)
-    if(MOCK_MESSAGE)
-      set(${MODE}_MESSAGE "${MESSAGE}" PARENT_SCOPE)
-    else()
-      _message(${MODE} ${MESSAGE})
-    endif()
-  endmacro()
-
-  include(GitCheckout)
+  set(MOCK_MESSAGE ON)
 
   function(foo)
     _set_error("Unknown error")
@@ -25,16 +21,14 @@ if("Set error" MATCHES ${TEST_MATCHES})
 
   foo()
 
-  set(MOCK_MESSAGE off)
   if(NOT FATAL_ERROR_MESSAGE STREQUAL "Unknown error")
+    set(MOCK_MESSAGE OFF)
     message(FATAL_ERROR "It should have set the error to 'Unknown error' but instead got '${FATAL_ERROR_MESSAGE}'")
   endif()
 endif()
 
 if("Set error with variable specified" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
-
-  include(GitCheckout)
 
   function(foo)
     _set_error("Unknown error" ERROR_VARIABLE ERR)


### PR DESCRIPTION
This pull request resolves #35 by introducing the following changes:
- Renames the `GitAssertion.cmake` module to `Assertion.cmake` and adds an include guard at the top of it.
- Adds a mock for the `message` function, which defaults to disabled and can be enabled by setting the `MOCK_MESSAGE` variable.
- Adds an `assert_message` function to assert whether the given message is received.