### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # GitCheckout.cmake
 
-[![version](https://img.shields.io/github/v/release/threeal/git-checkout-cmake?style=flat-square)](https://github.com/threeal/git-checkout-cmake/releases)
-[![license](https://img.shields.io/github/license/threeal/git-checkout-cmake?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/git-checkout-cmake/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/git-checkout-cmake/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/git-checkout-cmake/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/git-checkout-cmake/actions/workflows/test.yaml)
-
 GitCheckout.cmake is a [CMake](https://cmake.org/) module for cloning and checking out a [Git](https://git-scm.com/) repository from your CMake project.
 
 ## License


### PR DESCRIPTION
This pull request resolves #39 by simply removing badges from the `README.md` file.