### PR TITLE
Host Modules on GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,35 @@
+name: Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  deploy-pages:
+    name: Deploy Pages
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+
+      - name: Copy Modules
+        run: |
+          mkdir -p build/page
+          cp cmake/GitCheckout.cmake build/page/latest
+
+      - name: Upload Documentation
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: build/page
+
+      - name: Deploy Pages
+        id: deploy-pages
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This pull request resolves #49 by adding a new workflow for deploying the latest version of the `GitCheckout.cmake` module on GitHub Pages.