### PR TITLE
Host All Module Versions on GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,11 +19,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2
+        with:
+          fetch-depth: 0
 
       - name: Copy Modules
         run: |
           mkdir -p build/page
           cp cmake/GitCheckout.cmake build/page/$(git branch --show-current)
+          for tag in $(git tag); do
+            git checkout $tag
+            cp cmake/GitCheckout.cmake build/page/$tag
+          done
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Copy Modules
         run: |
           mkdir -p build/page
-          cp cmake/GitCheckout.cmake build/page/latest
+          cp cmake/GitCheckout.cmake build/page/$(git branch --show-current)
 
       - name: Upload Documentation
         uses: actions/upload-pages-artifact@v3.0.1


### PR DESCRIPTION
This pull request resolves #52 by modifying the `deploy-pages` job in the `deploy` workflow to deploy all available versions of the `GitCheckout.cmake` module on GitHub Pages based on the Git tags.