### PR TITLE
Utilize FindGit to Check for Git Existence

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,11 @@ function(add_cmake_test FILE)
 endfunction()
 
 add_cmake_test(
+  cmake/FindGitTest.cmake
+  "Find the Git executable"
+)
+
+add_cmake_test(
   cmake/GitCloneTest.cmake
   "Incompletely clone a Git repository"
   "Incompletely clone a Git repository to an existing path"

--- a/test/cmake/FindGitTest.cmake
+++ b/test/cmake/FindGitTest.cmake
@@ -1,0 +1,26 @@
+# Matches everything if not defined
+if(NOT TEST_MATCHES)
+  set(TEST_MATCHES ".*")
+endif()
+
+set(TEST_COUNT 0)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+include(GitCheckout)
+
+if("Find the Git executable" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  _find_git()
+
+  if(NOT DEFINED GIT_EXECUTABLE)
+    message(FATAL_ERROR "The 'GIT_EXECUTABLE' variable should be defined")
+  elseif(NOT EXISTS ${GIT_EXECUTABLE})
+    message(FATAL_ERROR "The Git executable should exist at '${GIT_EXECUTABLE}'")
+  endif()
+endif()
+
+if(TEST_COUNT LESS_EQUAL 0)
+  message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
+endif()


### PR DESCRIPTION
This pull request resolves #59 by adding a `_find_git` function that utilizes the [FindGit](https://cmake.org/cmake/help/latest/module/FindGit.html) module to check whether Git is available in the system or not.