### PR TITLE
Allow Check Out to Existing Git Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 
 project(
   GitCheckout
-  VERSION 1.0.0
+  VERSION 1.1.0
   DESCRIPTION "Clone and check out a Git repository from a CMake project"
   HOMEPAGE_URL https://github.com/threeal/git-checkout-cmake
   LANGUAGES NONE

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ This module can be integrated into a CMake project in the following ways:
 - Use [`file(DOWNLOAD)`](https://cmake.org/cmake/help/latest/command/file.html#download) to automatically download the `GitCheckout.cmake` file:
   ```cmake
   file(
-    DOWNLOAD "https://threeal.github.io/git-checkout-cmake/v1.0.0"
+    DOWNLOAD "https://threeal.github.io/git-checkout-cmake/v1.1.0"
     "${CMAKE_BINARY_DIR}/GitCheckout.cmake"
   )
   include("${CMAKE_BINARY_DIR}/GitCheckout.cmake")
   ```
 - Use [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to add this package to the CMake project:
   ```cmake
-  cpmaddpackage("gh:threeal/git-checkout-cmake@1.0.0")
+  cpmaddpackage("gh:threeal/git-checkout-cmake@1.1.0")
   include("${GitCheckout_SOURCE_DIR}/cmake/GitCheckout.cmake")
   ```
 

--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -34,18 +34,24 @@ function(_git_incomplete_clone URL)
     string(REGEX REPLACE ".*/" "" ARG_DIRECTORY ${URL})
   endif()
 
-  if(EXISTS ${ARG_DIRECTORY})
-    message(FATAL_ERROR "Unable to clone '${URL}' to '${ARG_DIRECTORY}' because the path already exists")
-  endif()
-
   _find_git()
 
-  execute_process(
-    COMMAND ${GIT_EXECUTABLE} clone --filter=blob:none --no-checkout ${URL} ${ARG_DIRECTORY}
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to clone '${URL}' (${RES})")
+  if(EXISTS ${ARG_DIRECTORY})
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C ${ARG_DIRECTORY} rev-parse --is-inside-work-tree
+      RESULT_VARIABLE RES
+    )
+    if(NOT RES EQUAL 0)
+      message(FATAL_ERROR "Unable to clone '${URL}' to '${ARG_DIRECTORY}' because the path already exists and is not a Git repository")
+    endif()
+  else()
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} clone --filter=blob:none --no-checkout ${URL} ${ARG_DIRECTORY}
+      RESULT_VARIABLE RES
+    )
+    if(NOT RES EQUAL 0)
+      message(FATAL_ERROR "Failed to clone '${URL}' (${RES})")
+    endif()
   endif()
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,8 +29,11 @@ add_cmake_test(
 add_cmake_test(
   cmake/GitCheckoutTest.cmake
   "Check out a Git repository"
+  "Check out a Git repository into an existing Git directory"
   "Check out a Git repository to a specific directory"
   "Check out a Git repository on a specific ref"
   "Check out a Git repository on a specific invalid ref"
+  "Check out a Git repository into an existing Git directory on a specific ref"
   "Check out a Git repository sparsely"
+  "Check out a Git repository into an existing Git directory sparsely"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,8 @@ add_cmake_test(
 add_cmake_test(
   cmake/GitCloneTest.cmake
   "Incompletely clone a Git repository"
-  "Incompletely clone a Git repository to an existing path"
+  "Incompletely clone a Git repository into an existing Git directory"
+  "Incompletely clone a Git repository into an existing path"
   "Incompletely clone an invalid Git repository"
   "Incompletely clone a Git repository to a specific directory"
 )

--- a/test/cmake/GitCheckoutTest.cmake
+++ b/test/cmake/GitCheckoutTest.cmake
@@ -13,6 +13,14 @@ function(check_out_a_git_repository)
   assert_git_complete_checkout(project-starter)
 endfunction()
 
+function(check_out_a_git_repository_into_an_existing_git_directory)
+  check_out_a_git_repository()
+
+  git_checkout(https://github.com/threeal/project-starter)
+
+  assert_git_complete_checkout(project-starter)
+endfunction()
+
 function(check_out_a_git_repository_to_a_specific_directory)
   if(EXISTS some-directory)
     file(REMOVE_RECURSE some-directory)
@@ -53,20 +61,39 @@ function(check_out_a_git_repository_on_a_specific_invalid_ref)
   assert_message(FATAL_ERROR "Failed to check out 'project-starter' to 'invalid-ref' (1)")
 endfunction()
 
+function(check_out_a_git_repository_into_an_existing_git_directory_on_a_specific_ref)
+  check_out_a_git_repository_on_a_specific_ref()
+
+  git_checkout(https://github.com/threeal/project-starter REF 316dec5)
+
+  assert_git_complete_checkout(project-starter)
+
+  execute_process(
+    COMMAND git -C project-starter rev-parse --short HEAD
+    OUTPUT_VARIABLE COMMIT_SHA
+  )
+  string(STRIP ${COMMIT_SHA} COMMIT_SHA)
+  if(NOT COMMIT_SHA STREQUAL 316dec5)
+    message(FATAL_ERROR "The commit SHA should be '316dec5' but instead got '${COMMIT_SHA}'")
+  endif()
+endfunction()
+
 function(check_out_a_git_repository_sparsely)
   if(EXISTS opencv)
     file(REMOVE_RECURSE opencv)
   endif()
 
-  git_checkout(
-    https://github.com/opencv/opencv
-    SPARSE_CHECKOUT modules/core samples/gpu
-  )
+  git_checkout(https://github.com/opencv/opencv SPARSE_CHECKOUT modules/core samples/gpu)
 
-  assert_git_sparse_checkout(
-    opencv
-    FILES modules/core samples/gpu
-  )
+  assert_git_sparse_checkout(opencv FILES modules/core samples/gpu)
+endfunction()
+
+function(check_out_a_git_repository_into_an_existing_git_directory_sparsely)
+  check_out_a_git_repository_sparsely()
+
+  git_checkout(https://github.com/opencv/opencv SPARSE_CHECKOUT modules/core modules/imgproc)
+
+  assert_git_sparse_checkout(opencv FILES modules/core modules/imgproc)
 endfunction()
 
 if(NOT DEFINED TEST_COMMAND)

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -22,7 +22,7 @@ function(incompletely_clone_a_git_repository_to_an_existing_path)
   set(MOCK_MESSAGE ON)
   _git_incomplete_clone(https://github.com/threeal/project-starter)
 
-  assert_message(FATAL_ERROR "Unable to clone 'https://github.com/threeal/project-starter' to 'project-starter' because the path already exists")
+  assert_message(FATAL_ERROR "Unable to clone 'https://github.com/threeal/project-starter' to 'project-starter' because the path already exists and is not a Git repository")
 endfunction()
 
 function(incompletely_clone_an_invalid_git_repository)

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -13,7 +13,14 @@ function(incompletely_clone_a_Git_repository)
   assert_git_incomplete_clone(project-starter)
 endfunction()
 
-function(incompletely_clone_a_git_repository_to_an_existing_path)
+function(incompletely_clone_a_git_repository_into_an_existing_git_directory)
+  incompletely_clone_a_Git_repository()
+
+  _git_incomplete_clone(https://github.com/threeal/project-starter)
+  assert_git_incomplete_clone(project-starter)
+endfunction()
+
+function(incompletely_clone_a_git_repository_into_an_existing_path)
   if(EXISTS project-starter)
     file(REMOVE_RECURSE project-starter)
   endif()


### PR DESCRIPTION
This pull request resolves #61 by modifying the `_git_incomplete_clone` function to ignore cloning if the output directory already exists and contains a Git repository. This way, this function could be run multiple times even if the Git repository is already cloned to the output directory. This change also adds more tests to test this behavior when the output directory already exists and contains a Git repository. It also bumps the project version to 1.1.0.