### PR TITLE
Remove Minimum CMake Requirement in Assertion Module

### DIFF
--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -1,7 +1,5 @@
 include_guard(GLOBAL)
 
-cmake_minimum_required(VERSION 3.3)
-
 # Mocks the implementation of the `message` function.
 #
 # If `MOCK_MESSAGE` is enabled, it will set `${MODE}_MESSAGE` to the given message instead of


### PR DESCRIPTION
This pull request resolves #65 by simply removing the `cmake_minimum_required` call in the `Assertion.cmake` module.