### PR TITLE
Modify Git Complete Checkout Assertion to Optionally Assert Commit SHA

### DIFF
--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -78,7 +78,12 @@ endfunction()
 #
 # Arguments:
 #   - DIRECTORY: The path of the directory to check out the Git repository.
+#
+# Optional arguments:
+#   - EXPECTED_COMMIT_SHA: The expected commit SHA of the checked out Git repository.
 function(assert_git_complete_checkout DIRECTORY)
+  cmake_parse_arguments(ARG "" EXPECTED_COMMIT_SHA "" ${ARGN})
+
   _assert_git_directory(${DIRECTORY})
 
   execute_process(
@@ -87,6 +92,17 @@ function(assert_git_complete_checkout DIRECTORY)
   )
   if(NOT RES EQUAL 0)
     message(FATAL_ERROR "the repository should be checked out completely (${RES})")
+  endif()
+
+  if(DEFINED ARG_EXPECTED_COMMIT_SHA)
+    execute_process(
+      COMMAND git -C ${DIRECTORY} rev-parse --short HEAD
+      OUTPUT_VARIABLE COMMIT_SHA
+    )
+    string(STRIP ${COMMIT_SHA} COMMIT_SHA)
+    if(NOT COMMIT_SHA STREQUAL ${ARG_EXPECTED_COMMIT_SHA})
+      message(FATAL_ERROR "The commit SHA should be '${ARG_EXPECTED_COMMIT_SHA}' but instead got '${COMMIT_SHA}'")
+    endif()
   endif()
 endfunction()
 

--- a/test/cmake/GitCheckoutTest.cmake
+++ b/test/cmake/GitCheckoutTest.cmake
@@ -38,16 +38,7 @@ function(check_out_a_git_repository_on_a_specific_ref)
 
   git_checkout(https://github.com/threeal/project-starter REF 5a80d20)
 
-  assert_git_complete_checkout(project-starter)
-
-  execute_process(
-    COMMAND git -C project-starter rev-parse --short HEAD
-    OUTPUT_VARIABLE COMMIT_SHA
-  )
-  string(STRIP ${COMMIT_SHA} COMMIT_SHA)
-  if(NOT COMMIT_SHA STREQUAL 5a80d20)
-    message(FATAL_ERROR "The commit SHA should be '5a80d20' but instead got '${COMMIT_SHA}'")
-  endif()
+  assert_git_complete_checkout(project-starter EXPECTED_COMMIT_SHA 5a80d20)
 endfunction()
 
 function(check_out_a_git_repository_on_a_specific_invalid_ref)
@@ -66,16 +57,7 @@ function(check_out_a_git_repository_into_an_existing_git_directory_on_a_specific
 
   git_checkout(https://github.com/threeal/project-starter REF 316dec5)
 
-  assert_git_complete_checkout(project-starter)
-
-  execute_process(
-    COMMAND git -C project-starter rev-parse --short HEAD
-    OUTPUT_VARIABLE COMMIT_SHA
-  )
-  string(STRIP ${COMMIT_SHA} COMMIT_SHA)
-  if(NOT COMMIT_SHA STREQUAL 316dec5)
-    message(FATAL_ERROR "The commit SHA should be '316dec5' but instead got '${COMMIT_SHA}'")
-  endif()
+  assert_git_complete_checkout(project-starter EXPECTED_COMMIT_SHA 316dec5)
 endfunction()
 
 function(check_out_a_git_repository_sparsely)


### PR DESCRIPTION
This pull request resolves #67 by adding an optional `EXPECTED_COMMIT_SHA` argument to the `assert_git_complete_checkout` function for specifying the expected commit SHA of the checked-out Git repository.