### PR TITLE
Modify Git Incomplete Clone Function to Always Require Directory Argument

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -18,35 +18,25 @@ endfunction()
 
 # Incompletely clones a Git repository from a remote location.
 #
-# It incompletely clones the Git repository to a specified directory without
-# checking out any files from the repository.
+# It incompletely clones a Git repository to a specified directory without checking out any files.
 #
 # Arguments:
 #   - URL: The URL of the remote Git repository.
-#
-# Optional arguments:
 #   - DIRECTORY: The path of the directory to check out the Git repository.
-function(_git_incomplete_clone URL)
-  cmake_parse_arguments(ARG "" "DIRECTORY" "" ${ARGN})
-
-  if(NOT DEFINED ARG_DIRECTORY)
-    # Determines the directory of the cloned Git repository if it is not specified.
-    string(REGEX REPLACE ".*/" "" ARG_DIRECTORY ${URL})
-  endif()
-
+function(_git_incomplete_clone URL DIRECTORY)
   _find_git()
 
-  if(EXISTS ${ARG_DIRECTORY})
+  if(EXISTS ${DIRECTORY})
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} -C ${ARG_DIRECTORY} rev-parse --is-inside-work-tree
+      COMMAND ${GIT_EXECUTABLE} -C ${DIRECTORY} rev-parse --is-inside-work-tree
       RESULT_VARIABLE RES
     )
     if(NOT RES EQUAL 0)
-      message(FATAL_ERROR "Unable to clone '${URL}' to '${ARG_DIRECTORY}' because the path already exists and is not a Git repository")
+      message(FATAL_ERROR "Unable to clone '${URL}' to '${DIRECTORY}' because the path already exists and is not a Git repository")
     endif()
   else()
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} clone --filter=blob:none --no-checkout ${URL} ${ARG_DIRECTORY}
+      COMMAND ${GIT_EXECUTABLE} clone --filter=blob:none --no-checkout ${URL} ${DIRECTORY}
       RESULT_VARIABLE RES
     )
     if(NOT RES EQUAL 0)
@@ -67,12 +57,12 @@ endfunction()
 function(git_checkout URL)
   cmake_parse_arguments(ARG "" "DIRECTORY;REF" "SPARSE_CHECKOUT" ${ARGN})
 
-  _git_incomplete_clone(${URL} DIRECTORY ${ARG_DIRECTORY})
-
   if(NOT DEFINED ARG_DIRECTORY)
     # Determines the directory of the cloned Git repository if it is not specified.
     string(REGEX REPLACE ".*/" "" ARG_DIRECTORY ${URL})
   endif()
+
+  _git_incomplete_clone(${URL} ${ARG_DIRECTORY})
 
   _find_git()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,6 @@ add_cmake_test(
   "Incompletely clone a Git repository into an existing Git directory"
   "Incompletely clone a Git repository into an existing path"
   "Incompletely clone an invalid Git repository"
-  "Incompletely clone a Git repository to a specific directory"
 )
 
 add_cmake_test(

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -8,7 +8,7 @@ function(test_incompletely_clone_a_Git_repository)
     file(REMOVE_RECURSE project-starter)
   endif()
 
-  _git_incomplete_clone(https://github.com/threeal/project-starter)
+  _git_incomplete_clone(https://github.com/threeal/project-starter project-starter)
 
   assert_git_incomplete_clone(project-starter)
 endfunction()
@@ -16,7 +16,7 @@ endfunction()
 function(test_incompletely_clone_a_git_repository_into_an_existing_git_directory)
   test_incompletely_clone_a_Git_repository()
 
-  _git_incomplete_clone(https://github.com/threeal/project-starter)
+  _git_incomplete_clone(https://github.com/threeal/project-starter project-starter)
   assert_git_incomplete_clone(project-starter)
 endfunction()
 
@@ -27,14 +27,14 @@ function(test_incompletely_clone_a_git_repository_into_an_existing_path)
   file(TOUCH project-starter)
 
   set(MOCK_MESSAGE ON)
-  _git_incomplete_clone(https://github.com/threeal/project-starter)
+  _git_incomplete_clone(https://github.com/threeal/project-starter project-starter)
 
   assert_message(FATAL_ERROR "Unable to clone 'https://github.com/threeal/project-starter' to 'project-starter' because the path already exists and is not a Git repository")
 endfunction()
 
 function(test_incompletely_clone_an_invalid_git_repository)
   set(MOCK_MESSAGE ON)
-  _git_incomplete_clone(https://github.com/threeal/invalid-project)
+  _git_incomplete_clone(https://github.com/threeal/invalid-project invalid-project)
 
   assert_message(FATAL_ERROR "Failed to clone 'https://github.com/threeal/invalid-project' (128)")
 endfunction()
@@ -44,7 +44,7 @@ function(test_incompletely_clone_a_git_repository_to_a_specific_directory)
     file(REMOVE_RECURSE some-directory)
   endif()
 
-  _git_incomplete_clone(https://github.com/threeal/project-starter DIRECTORY some-directory)
+  _git_incomplete_clone(https://github.com/threeal/project-starter some-directory)
 
   assert_git_incomplete_clone(some-directory)
 endfunction()

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -39,16 +39,6 @@ function(test_incompletely_clone_an_invalid_git_repository)
   assert_message(FATAL_ERROR "Failed to clone 'https://github.com/threeal/invalid-project' (128)")
 endfunction()
 
-function(test_incompletely_clone_a_git_repository_to_a_specific_directory)
-  if(EXISTS some-directory)
-    file(REMOVE_RECURSE some-directory)
-  endif()
-
-  _git_incomplete_clone(https://github.com/threeal/project-starter some-directory)
-
-  assert_git_incomplete_clone(some-directory)
-endfunction()
-
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
 elseif(NOT COMMAND test_${TEST_COMMAND})


### PR DESCRIPTION
This pull request resolves #75 by introducing the following changes:
- Modifies the `_git_incomplete_clone` function to always require the `DIRECTORY` argument.
- Removes the `test_incompletely_clone_a_git_repository_to_a_specific_directory` test function.