### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/cmake/GitCheckout.cmake
+++ b/cmake/GitCheckout.cmake
@@ -79,7 +79,7 @@ endfunction()
 #   - REF: The reference (branch, tag, or commit) to check out the Git repository.
 #   - SPARSE_CHECKOUT: A list of files to check out sparsely.
 function(git_checkout URL)
-  cmake_parse_arguments(ARG "" "DIRECTORY;REF" "SPARSE_CHECKOUT" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "DIRECTORY;REF" "SPARSE_CHECKOUT")
 
   _get_git_checkout_directory("${URL}" "${ARG_DIRECTORY}" ARG_DIRECTORY)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -59,7 +59,7 @@ endfunction()
 # Optional arguments:
 #   - EXPECTED_COMMIT_SHA: The expected commit SHA of the checked out Git repository.
 function(assert_git_complete_checkout DIRECTORY)
-  cmake_parse_arguments(ARG "" EXPECTED_COMMIT_SHA "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" EXPECTED_COMMIT_SHA "")
 
   _assert_git_directory("${DIRECTORY}")
 

--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -91,7 +91,7 @@ endfunction()
 # Optional arguments:
 #   - FILES: A list of files that should be checked out sparsely.
 function(assert_git_sparse_checkout DIRECTORY)
-  cmake_parse_arguments(ARG "" "" "FILES" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "FILES")
 
   assert_git_complete_checkout("${DIRECTORY}")
 


### PR DESCRIPTION
This pull request resolves #95 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `cmake_parse_arguments(PARSE_ARGV)` function in the `git_checkout`, `assert_git_complete_checkout`, and `assert_git_sparse_checkout` functions.