### PR TITLE
Utilize Version 0.2.0 of Assertion.cmake Module

### DIFF
--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -1,8 +1,9 @@
 include_guard(GLOBAL)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.1.0 ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 3c9c0dd5e971bde719d7151c673e08b4
+  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+    ${CMAKE_BINARY_DIR}/Assertion.cmake
+  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
@@ -15,8 +16,8 @@ include(GitCheckout)
 # Arguments:
 #   - PATH: The path to check.
 function(_assert_git_directory PATH)
-  assert_exists("${PATH}")
-  assert_directory("${PATH}")
+  assert(EXISTS "${PATH}")
+  assert(IS_DIRECTORY "${PATH}")
 
   _find_git()
 
@@ -79,7 +80,7 @@ function(assert_git_complete_checkout DIRECTORY)
       OUTPUT_VARIABLE COMMIT_SHA
     )
     string(STRIP "${COMMIT_SHA}" COMMIT_SHA)
-    assert_strequal("${COMMIT_SHA}" "${ARG_EXPECTED_COMMIT_SHA}")
+    assert(COMMIT_SHA STREQUAL ARG_EXPECTED_COMMIT_SHA)
   endif()
 endfunction()
 

--- a/test/cmake/GitOtherTest.cmake
+++ b/test/cmake/GitOtherTest.cmake
@@ -1,6 +1,7 @@
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.1.0 ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 3c9c0dd5e971bde719d7151c673e08b4
+  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+    ${CMAKE_BINARY_DIR}/Assertion.cmake
+  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
@@ -9,29 +10,29 @@ include(GitCheckout)
 function("Find the Git executable")
   _find_git()
 
-  assert_defined(GIT_EXECUTABLE)
-  assert_exists("${GIT_EXECUTABLE}")
+  assert(DEFINED GIT_EXECUTABLE)
+  assert(EXISTS "${GIT_EXECUTABLE}")
 endfunction()
 
 function("Get the Git check out directory with an absolute directory provided")
   _get_git_checkout_directory(https://github.com/threeal/project-starter /path/to/some-directory DIRECTORY)
 
-  assert_defined(DIRECTORY)
-  assert_strequal("${DIRECTORY}" /path/to/some-directory)
+  assert(DEFINED DIRECTORY)
+  assert(DIRECTORY STREQUAL /path/to/some-directory)
 endfunction()
 
 function("Get the Git check out directory with a relative directory provided")
   _get_git_checkout_directory(https://github.com/threeal/project-starter some-directory DIRECTORY)
 
-  assert_defined(DIRECTORY)
-  assert_strequal("${DIRECTORY}" ${CMAKE_CURRENT_BINARY_DIR}/some-directory)
+  assert(DEFINED DIRECTORY)
+  assert(DIRECTORY STREQUAL ${CMAKE_CURRENT_BINARY_DIR}/some-directory)
 endfunction()
 
 function("Get the Git check out directory without any directory provided")
   _get_git_checkout_directory(https://github.com/threeal/project-starter "" DIRECTORY)
 
-  assert_defined(DIRECTORY)
-  assert_strequal("${DIRECTORY}" ${CMAKE_CURRENT_BINARY_DIR}/project-starter)
+  assert(DEFINED DIRECTORY)
+  assert(DIRECTORY STREQUAL ${CMAKE_CURRENT_BINARY_DIR}/project-starter)
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #97 by utilizing version 0.2.0 of the Assertion.cmake module.