### PR TITLE
Utilize `PROJECT_IS_TOP_LEVEL` Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(
   GitCheckout
@@ -8,16 +8,12 @@ project(
   LANGUAGES NONE
 )
 
-if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(SUBPROJECT TRUE)
-endif()
-
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-if(SUBPROJECT)
+if(NOT PROJECT_IS_TOP_LEVEL)
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 endif()
 
-if(NOT SUBPROJECT)
+if(PROJECT_IS_TOP_LEVEL)
   if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(test)


### PR DESCRIPTION
This pull request resolves #98 by utilizing the `PROJECT_IS_TOP_LEVEL` variable, replacing the `SUBPROJECT` variable. This change also bumps the minimum CMake version to 3.21.