### PR TITLE
Bump Assertion.cmake to Version 0.3.0

### DIFF
--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -1,9 +1,9 @@
 include_guard(GLOBAL)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 

--- a/test/cmake/GitCheckoutTest.cmake
+++ b/test/cmake/GitCheckoutTest.cmake
@@ -46,11 +46,9 @@ function("Check out a Git repository on a specific invalid ref")
     file(REMOVE_RECURSE project-starter)
   endif()
 
-  mock_message()
-    git_checkout(https://github.com/threeal/project-starter REF invalid-ref)
-  end_mock_message()
-
-  assert_message(FATAL_ERROR "Failed to check out '${CMAKE_CURRENT_BINARY_DIR}/project-starter' to 'invalid-ref' (1)")
+  assert_fatal_error(
+    CALL git_checkout https://github.com/threeal/project-starter REF invalid-ref
+    MESSAGE "Failed to check out '${CMAKE_CURRENT_BINARY_DIR}/project-starter' to 'invalid-ref' (1)")
 endfunction()
 
 function("Check out a Git repository into an existing Git directory on a specific ref")

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -26,19 +26,15 @@ function("Incompletely clone a Git repository into an existing path")
   endif()
   file(TOUCH project-starter)
 
-  mock_message()
-    _git_incomplete_clone(https://github.com/threeal/project-starter project-starter)
-  end_mock_message()
-
-  assert_message(FATAL_ERROR "Unable to clone 'https://github.com/threeal/project-starter' to 'project-starter' because the path already exists and is not a Git repository")
+  assert_fatal_error(
+    CALL _git_incomplete_clone https://github.com/threeal/project-starter project-starter
+    MESSAGE "Unable to clone 'https://github.com/threeal/project-starter' to 'project-starter' because the path already exists and is not a Git repository")
 endfunction()
 
 function("Incompletely clone an invalid Git repository")
-  mock_message()
-    _git_incomplete_clone(https://github.com/threeal/invalid-project invalid-project)
-  end_mock_message()
-
-  assert_message(FATAL_ERROR "Failed to clone 'https://github.com/threeal/invalid-project' (128)")
+  assert_fatal_error(
+    CALL _git_incomplete_clone https://github.com/threeal/invalid-project invalid-project
+    MESSAGE "Failed to clone 'https://github.com/threeal/invalid-project' (128)")
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/GitOtherTest.cmake
+++ b/test/cmake/GitOtherTest.cmake
@@ -1,7 +1,7 @@
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 


### PR DESCRIPTION
This pull request updates the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [0.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v0.3.0). It also modifies lines that use the `assert_message` function to use the `assert_fatal_error` function instead.