### PR TITLE
Bump Assertion.cmake to Version 1.0.0

### DIFF
--- a/test/cmake/Assertion.cmake
+++ b/test/cmake/Assertion.cmake
@@ -1,9 +1,9 @@
 include_guard(GLOBAL)
 
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 

--- a/test/cmake/GitCheckoutTest.cmake
+++ b/test/cmake/GitCheckoutTest.cmake
@@ -49,7 +49,7 @@ function("Check out a Git repository on a specific invalid ref")
 
   assert_fatal_error(
     CALL git_checkout https://github.com/threeal/project-starter REF invalid-ref
-    MESSAGE "Failed to check out '${CMAKE_CURRENT_BINARY_DIR}/project-starter' to 'invalid-ref' (1)")
+    MESSAGE "Failed to check out '${CMAKE_CURRENT_BINARY_DIR}/project-starter' to 'invalid-ref'")
 endfunction()
 
 function("Check out a Git repository into an existing Git directory on a specific ref")

--- a/test/cmake/GitCloneTest.cmake
+++ b/test/cmake/GitCloneTest.cmake
@@ -35,7 +35,7 @@ endfunction()
 function("Incompletely clone an invalid Git repository")
   assert_fatal_error(
     CALL _git_incomplete_clone https://github.com/threeal/invalid-project invalid-project
-    MESSAGE "Failed to clone 'https://github.com/threeal/invalid-project' (128)")
+    MESSAGE "Failed to clone 'https://github.com/threeal/invalid-project'")
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/GitOtherTest.cmake
+++ b/test/cmake/GitOtherTest.cmake
@@ -1,7 +1,7 @@
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [1.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v1.0.0).